### PR TITLE
Remove previous cards when updating recipe display

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -37,6 +37,7 @@ tags.addEventListener('click', tagsToggleFilter)
 // --------------------------------------------- FUNCTIONS
 
 function updateAllRecipeDisplay(recipesToDisplay) {
+  recipeSection.innerHTML = ''
     recipesToDisplay.forEach((recipe) => {
     const tagsHTML = buildTags(recipe)
     const recipeCard = document.createElement('section')


### PR DESCRIPTION
What does this PR do?

- Adds one line in `updateAllRecipeDisplay` to remove the previous recipes cards before adding new recipe cards. Before this, the filter function was creating the filtered recipes and appending it to the end of all the previous recipes instead of replacing them.

Where should your reviewer start?

What (if any) features are you implementing?

What (if anything) did you refactor?

Were there any issues that arose?

Is there anything that you need from your teammate?

Any other comments, questions, or concerns to add?
