### PR TITLE
Bugfix/clear search and tags.jw

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -266,6 +266,7 @@ function tagsToggleFilter(event) {
 };
 
 function addTag(event) {
+  clearSearchBar()
   const filterSelectedTags = store.tagList.filter((tag) =>
     tag.classList.contains('recipe-tag-selected')
   );
@@ -326,11 +327,13 @@ function searchRecipesByName(search) {
     let nameFilteredRecipes = store.recipeRepo.searchByName(search)
     updateRecipeDisplay(nameFilteredRecipes);
     changeSearchButton(clearAllRecipeSearchButton, searchAllRecipesButton);
+    deselectTag()
   } 
   else if (cookbookTab.checked && search.length > 0) {
     let nameFilteredRecipes = store.user.favoriteRecipeRepo.searchByName(search)
     updateRecipeDisplay(nameFilteredRecipes);
     changeSearchButton(clearCookbookSearchButton, searchCookbookButton);
+    deselectTag
   }
 };
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -333,7 +333,7 @@ function searchRecipesByName(search) {
     let nameFilteredRecipes = store.user.favoriteRecipeRepo.searchByName(search)
     updateRecipeDisplay(nameFilteredRecipes);
     changeSearchButton(clearCookbookSearchButton, searchCookbookButton);
-    deselectTag
+    deselectTag()
   }
 };
 


### PR DESCRIPTION
What does this PR do?
- Correctly deselect tag/clear search bar when other search method is being used. Previously, tags would remain 

Where should your reviewer start?
- Check searchRecipesByName (line 325), then addTag (line 268)

What (if any) features are you implementing?

What (if anything) did you refactor?

Were there any issues that arose?

Is there anything that you need from your teammate?

Any other comments, questions, or concerns to add?
