### PR TITLE
Refactor add all ingredients post request

### DIFF
--- a/src/postRequests.js
+++ b/src/postRequests.js
@@ -1,11 +1,5 @@
 const usersURL = 'http://localhost:3001/api/v1/users';
 
-function addAllIngredients(recipe, user) {
-  const neededIngredients = user.getMissingIngredientsForRecipe(recipe);
-  const requests = createPostRequests(user, neededIngredients);
-  return postAll(requests, user, recipe);
-}
-
 function createPostRequests(user, ingredients) {
   const postRequests = [];
   ingredients.forEach((ingredient) => {
@@ -31,14 +25,10 @@ function createPostRequests(user, ingredients) {
 }
 
 function postAll(requests) {
-  console.log('PROMISES', requests);
+
   return Promise.all(requests)
-    .then((data) => {
-      data.forEach((response) => {
-        console.log(response);
-      });
-    })
-    .catch((err) => console.error(err));
+    .then((data) => data)
+    .catch((err) => console.error('AHHHH', err));
 }
 
-export { addAllIngredients, createPostRequests, postAll };
+export { createPostRequests, postAll };

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,6 +1,6 @@
 import './styles.css';
 import { fetchAll } from './apiCalls';
-import { addAllIngredients } from './post';
+import { createPostRequests, postAll } from './postRequests';
 import Glide from '@glidejs/glide';
 import RecipeRepository from './classes/RecipeRepository';
 import User from './classes/User';
@@ -88,6 +88,33 @@ const initializeApp = () => {
     })
     .catch((err) => console.error(err));
 };
+
+// ------------------- Post to Server ------------------
+
+function addAllIngredients(recipe, user) {
+  const neededIngredients = user.getMissingIngredientsForRecipe(recipe);
+  const requests = createPostRequests(user, neededIngredients);
+  postAll(requests)
+    .then((data) => {
+      data.forEach((response) => {
+        console.log(response);
+      });
+      store.user.addPantryIngredients(
+        store.currentRecipe,
+        store.ingredientsData
+      );
+      populatePantryDisplay();
+      console.log(
+        'MISSING AFTER',
+        store.user.getMissingIngredientsForRecipe(store.currentRecipe)
+      );
+      console.log('NEW PANTRY: ', store.user.pantry);
+    })
+    .catch((err) => {
+      console.error(err);
+      popupError.style.display = 'block';
+    });
+}
 
 // ------------------- EVENT LISTENERS ------------------
 window.addEventListener('load', initializeApp);
@@ -362,12 +389,11 @@ function buildModal(recipe) {
 
 function addRecipesToPantry(event) {
   if (event.target.id === 'addIngredientsBtn') {
-    console.log("RECIPE", store.currentRecipe)
-    addAllIngredients(store.currentRecipe, store.user);
-
-    store.user.addPantryIngredients(store.currentRecipe, store.ingredientsData);
-
-    console.log('NEW PANTRY: ', store.user.pantry);
+    console.log(
+      'MISSING BEFORE',
+      store.user.getMissingIngredientsForRecipe(store.currentRecipe)
+    );
+    addAllIngredients(store.currentRecipe, store.user, store.ingredientsData);
 
     missingIngredientModal.style.display = 'none';
     addIngredientSuccessPopup.style.display = 'block';


### PR DESCRIPTION
What does this PR do?

- [✔️] `Add all ingredients function` now lives in `scripts.js` in a `post request` section 
- [✔️]  `Add recipes to display function` is now refactored to only invoke `add all ingredients function`
- [✔️]  Our post request function is now responsible for `update the user pantry data` and `pantry display ui` once the promise is successfully resolved
- [✔️]  If any post request throws an error, catch will trigger and the user will get an `error popup` and `user pantry data and UI will not update`

Is there anything that you need from your teammate?

<img src="https://user-images.githubusercontent.com/108706408/200135128-bcea1910-3e55-4b1e-9208-53f315ed5fac.gif" height="40px"> `There are a lot of console logs left in order to verify the post request is working how we expect. This will be removed once the function is fully completed`
